### PR TITLE
[feature] add first iteration SettingsPresenter and GameSettings

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,9 +1,4 @@
----
-name: "Pull Request"
-about: "Add changes to the project"
-title: "[PR] "
-labels: ["enhancement"]
----
+
 <!-- You can remove sections that aren't applicable. -->
 <!-- Please remember to add additional labels as well as related milestone. -->
 

--- a/chessevolved_model/src/main/kotlin/io/github/chessevolved/singletons/GameSettings.kt
+++ b/chessevolved_model/src/main/kotlin/io/github/chessevolved/singletons/GameSettings.kt
@@ -1,0 +1,42 @@
+package io.github.chessevolved.singletons
+
+object GameSettings {
+    var fogOfWar: Boolean = false
+    var boardSize: Int = 8
+
+    /**
+     * Toggles Fog of War for the game
+     *
+     * @param enabled Boolean for enabeling/disabeling FOW
+     */
+    fun setFOW(enabled: Boolean) {
+        fogOfWar = enabled
+    }
+
+    /**
+     * The current setting of FOW
+     *
+     * @return Current FOW setting as Boolean
+     */
+    fun isFOWEnabled(): Boolean {
+        return fogOfWar
+    }
+
+    /**
+     * Sets a new size for the chessboard
+     *
+     * @param newSize Int for chessboard size
+     */
+    fun setBoardSize(newSize: Int) {
+        boardSize = newSize
+    }
+
+    /**
+     * The current chessboard size
+     *
+     * @return Size of the chessboard as Int
+     */
+    fun getBoardSize(): Int {
+        return boardSize
+    }
+}

--- a/chessevolved_presenter/src/main/kotlin/io/github/chessevolved/presenters/SettingsPresenter.kt
+++ b/chessevolved_presenter/src/main/kotlin/io/github/chessevolved/presenters/SettingsPresenter.kt
@@ -1,0 +1,43 @@
+package io.github.chessevolved.presenters
+
+import io.github.chessevolved.singletons.GameSettings
+
+class SettingsPresenter : IPresenter {
+
+    //TODO: wait for implementation of ScenePresenterStateManager
+    val gameSettings = GameSettings
+    //val presenterManager = ScenePresenterStateManager
+
+    /**
+     * Applies the chosen game settings
+     *
+     * @param fowSetting Boolean for Fog of War
+     * @param sizeSetting Int for size of chessboard
+     */
+    fun onApply(fowSetting: Boolean, sizeSetting: Int) {
+        //TODO: Consider if game settings should be applied manually or automatically
+        gameSettings.setFOW(fowSetting)
+
+        //TODO: validate max/min boardsize here?
+        gameSettings.setBoardSize(sizeSetting)
+    }
+
+    /**
+     * Retrieves the current game settings
+     *
+     * @return Current settings as a Map
+     */
+    fun getCurrentSettings(): Map<String, Any> {
+        return mapOf(
+            "FogOfWar" to gameSettings.isFOWEnabled(),
+            "BoardSize" to gameSettings.getBoardSize()
+        )
+    }
+
+    /**
+     *  Switch to LobbyPresenter
+     */
+    fun onBack() {
+        //TODO: wait for implementation of ScenePresenterStateManager
+    }
+}


### PR DESCRIPTION

<!-- You can remove sections that aren't applicable. -->
<!-- Please remember to add additional labels as well as related milestone. -->

## Description
<!-- A clear and concise description of what this PR does. -->
Adds a simple basic setup for SettingsPresenter with accompanying GameSettings singleton in model for storing selected settings.

## Related Issues
Closes: #11 

## Changes Made
- [x] Add SettingsPresenter.kt with basic functions for setting and retrieving settings from GameSettings.kt
- [x] Add GameSettings.kt singleton with a couple basic settings

## Checklist
### Check applicable items
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented on my code where necessary.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.

