### PR TITLE
[Feature] Add endgame presenter and view

### DIFF
--- a/chessevolved_presenter/src/main/kotlin/io/github/chessevolved/presenters/EndGamePresenter.kt
+++ b/chessevolved_presenter/src/main/kotlin/io/github/chessevolved/presenters/EndGamePresenter.kt
@@ -1,0 +1,46 @@
+package io.github.chessevolved.presenters
+
+import io.github.chessevolved.views.EndGameView
+
+class EndGamePresenter(
+    private val endGameView: EndGameView,
+    private val endGameStatus: Boolean,
+) : IPresenter {
+    init {
+        endGameView.endGameStatus = endGameStatus
+        endGameView.init()
+    }
+
+    /**
+     * Returns to the MenuPresenter
+     */
+    fun returnToMenu() {
+        print("Returning to menu...")
+    }
+
+    /**
+     * Restarts Game
+     */
+    fun rematch() {
+        print("Requesting rematch...")
+    }
+
+    override fun render() {
+        endGameView.render()
+    }
+
+    override fun resize(
+        width: Int,
+        height: Int,
+    ) {
+        endGameView.resize(width, height)
+    }
+
+    override fun dispose() {
+        endGameView.dispose()
+    }
+
+    override fun setInputProcessor() {
+        endGameView.setInputProcessor()
+    }
+}

--- a/chessevolved_view/src/main/kotlin/io/github/chessevolved/views/EndGameView.kt
+++ b/chessevolved_view/src/main/kotlin/io/github/chessevolved/views/EndGameView.kt
@@ -1,0 +1,81 @@
+package io.github.chessevolved.views
+
+import com.badlogic.gdx.Gdx
+import com.badlogic.gdx.scenes.scene2d.Stage
+import com.badlogic.gdx.utils.viewport.FitViewport
+import ktx.actors.onClick
+import ktx.scene2d.label
+import ktx.scene2d.scene2d
+import ktx.scene2d.table
+import ktx.scene2d.textButton
+
+class EndGameView : IView {
+    private val stage = Stage(FitViewport(Gdx.graphics.width.toFloat(), Gdx.graphics.height.toFloat()))
+
+    /**
+     * Weather to show win or loss
+     *
+     * true = win
+     *
+     * false = loss
+     */
+    var endGameStatus: Boolean = false
+        set(value) {
+            field = value
+        }
+
+    var onReturnToMenu: () -> Unit = {}
+    var onRematch: () -> Unit = {}
+
+    override fun init() {
+        val root =
+            scene2d.table {
+                // Set size of layout parent to screen.
+                setFillParent(true)
+                // Set padding to 10f
+                defaults().pad(10f)
+
+                // Perhaps replace label in the future with a logo. Or custom sprite text.
+                if (endGameStatus) {
+                    label("Congratulations!") { it.padBottom(20f).center() }
+                    row()
+                    label("You won!") { it.padBottom(20f).center() }
+                } else {
+                    label("Better luck next time!") { it.padBottom(20f).center() }
+                    row()
+                    label("You lost!") { it.padBottom(20f).center() }
+                }
+                row()
+                textButton("Return to menu") {
+                    it.padBottom(5f)
+                    onClick { onReturnToMenu() }
+                }
+                row()
+                textButton("Request rematch") {
+                    onClick { onRematch() }
+                }
+            }
+
+        stage.addActor(root)
+    }
+
+    override fun render() {
+        stage.act(Gdx.graphics.deltaTime)
+        stage.draw()
+    }
+
+    override fun resize(
+        width: Int,
+        height: Int,
+    ) {
+        stage.viewport.update(width, height, true)
+    }
+
+    override fun dispose() {
+        stage.dispose()
+    }
+
+    override fun setInputProcessor() {
+        Gdx.input.inputProcessor = stage
+    }
+}

--- a/chessevolved_view/src/main/kotlin/io/github/chessevolved/views/SettingsView.kt
+++ b/chessevolved_view/src/main/kotlin/io/github/chessevolved/views/SettingsView.kt
@@ -113,4 +113,7 @@ class SettingsView : IView {
     override fun dispose() {
         stage.dispose()
     }
+
+    override fun setInputProcessor() {
+    }
 }


### PR DESCRIPTION
<!-- You can remove sections that aren't applicable. -->
<!-- Please remember to add additional labels as well as related milestone. -->

## Description
<!-- A clear and concise description of what this PR does. -->
Adds a endgame screen that shows if the player lost or won the game. 
Gives the option to return to menu, or request a rematch.

## Related Issues
<!-- Reference related issues using `Fixes #issue_number` or `Closes #issue_number`. -->
Closes: #46 

## Changes Made
- [x] Added EndGamePresenter
- [x] Added EndGameView

## Screenshots (if applicable)
<!-- Add screenshots if your change includes UI updates. -->
![image](https://github.com/user-attachments/assets/e286c872-5618-4de1-ae5c-95a60006fb50)
![image](https://github.com/user-attachments/assets/8baf11a8-167f-4ed8-a75d-125cf0983f56)

## Checklist
### Check applicable items
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented on my code where necessary.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.

